### PR TITLE
Smooth drawing bugfix: RMB for drawing switched to SHIFT+RMB

### DIFF
--- a/sources/controls/waveformcontrol.cpp
+++ b/sources/controls/waveformcontrol.cpp
@@ -392,10 +392,12 @@ void WaveformControl::mousePressEvent(QMouseEvent* event)
                         }
                         else {
                             if (QGuiApplication::queryKeyboardModifiers() != Qt::ShiftModifier)
-                            m_pointGrabbed = false;
-                            qDebug() << "Deleting point";
-                            getChannel()->remove(m_clickPosition);
-                            update();
+                            {
+                                m_pointGrabbed = false;
+                                qDebug() << "Deleting point";
+                                getChannel()->remove(m_clickPosition);
+                                update();
+                            }
                         }
                     //}
                 }

--- a/sources/controls/waveformcontrol.cpp
+++ b/sources/controls/waveformcontrol.cpp
@@ -21,6 +21,7 @@
 #include <QDebug>
 #include <QSettings>
 #include <QFileInfo>
+#include <QGuiApplication>
 
 WaveformControl::WaveformControl(QQuickItem* parent) :
     QQuickPaintedItem(parent),
@@ -390,7 +391,9 @@ void WaveformControl::mousePressEvent(QMouseEvent* event)
                             qDebug() << "Grabbed point: " << getChannel()->operator[](m_clickPosition);
                         }
                         else {
+                            if (QGuiApplication::queryKeyboardModifiers() != Qt::ShiftModifier)
                             m_pointGrabbed = false;
+                            qDebug() << "Deleting point";
                             getChannel()->remove(m_clickPosition);
                             update();
                         }
@@ -490,7 +493,7 @@ void WaveformControl::mouseMoveEvent(QMouseEvent* event)
         break;
         // Smooth drawing at Repair mode
         case Qt::RightButton: {
-            if (m_operationMode == WaveformRepairMode) {
+            if (m_operationMode == WaveformRepairMode && QGuiApplication::queryKeyboardModifiers() == Qt::ShiftModifier) {
                 const auto* ch = getChannel();
                 if (!ch) {
                     return;


### PR DESCRIPTION
Problem of simultaneous Right Mouse Button action solved.
RMB was deleting current point and was making smooth drawing.
Smooth drawing is now produced with RMB while SHIFT is pressed.